### PR TITLE
Implements gresource support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+
+
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# 4 space indentation
+[*.{ts,js}]
+indent_style = tab
+indent_size = 4
+
+# Matches the exact files either package.json or .travis.yml
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2
+

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "useTabs": true
+}

--- a/package.json
+++ b/package.json
@@ -29,5 +29,6 @@
     "ts-node": "^8.0.3",
     "tslint": "^5.13.1",
     "typescript": "^3.3.3333"
-  }
+  },
+  "dependencies": {}
 }

--- a/src/convertGResource.ts
+++ b/src/convertGResource.ts
@@ -1,10 +1,18 @@
 import { homedir } from "os";
-
-const { execSync } = require("child_process");
+import { execSync } from "child_process";
+import { writeFileSync } from "fs";
 
 // Converts given gresource file if it has a css file.
-export const convertGResource = (theme: string, gresource: string) => {
-	execSync(`mkdir -p ${homedir()}/.config/node-gtk-theme/${theme}`, {
-		encoding: "utf8"
-	});
+export const convertGResource = (gresource: string) => {
+	const stdout = execSync(`gresource list ${gresource}`);
+	const output = stdout.toString();
+	const candidates = output
+		.split("\n")
+		.filter(e => e.includes("gtk.css")) || [""];
+	const assetName = candidates[0];
+
+	if (output.includes("gtk.css")) {
+		const data = execSync(`gresource extract ${gresource} ${assetName}`);
+		return data.toString();
+	}
 };

--- a/src/convertGResource.ts
+++ b/src/convertGResource.ts
@@ -1,0 +1,10 @@
+import { homedir } from "os";
+
+const { execSync } = require("child_process");
+
+// Converts given gresource file if it has a css file.
+export const convertGResource = (theme: string, gresource: string) => {
+	execSync(`mkdir -p ${homedir()}/.config/node-gtk-theme/${theme}`, {
+		encoding: "utf8"
+	});
+};

--- a/src/decorationLayout.ts
+++ b/src/decorationLayout.ts
@@ -1,4 +1,7 @@
-const { execSync } = require('child_process');
+const { execSync } = require("child_process");
 
 // Return a function to get the current theme.
-export const decorationLayout = () => execSync('gsettings get org.gnome.desktop.wm.preferences button-layout', { encoding: 'utf8' });
+export const decorationLayout = () =>
+	execSync("gsettings get org.gnome.desktop.wm.preferences button-layout", {
+		encoding: "utf8"
+	});

--- a/src/decorationLayout.ts
+++ b/src/decorationLayout.ts
@@ -1,4 +1,4 @@
-const { execSync } = require("child_process");
+import { execSync } from "child_process";
 
 // Return a function to get the current theme.
 export const decorationLayout = () =>

--- a/src/findGResourceAsset.ts
+++ b/src/findGResourceAsset.ts
@@ -1,6 +1,6 @@
-const { readdirSync } = require("fs");
-const { execSync } = require("child_process");
-const { knownGResourceAssets } = require("./knownGResourceAssets");
+import { readdirSync } from "fs";
+import { execSync } from "child_process";
+import { knownGResourceAssets } from "./knownGResourceAssets";
 
 interface Props {
 	theme: string;
@@ -11,12 +11,16 @@ export const findGResourceAsset = ({ theme, folder }: Props) => {
 	const asset = knownGResourceAssets[theme.toLocaleLowerCase()];
 
 	if (asset != null) {
-		console.log(asset);
 		return asset;
 	} else {
 		try {
 			const files = readdirSync(`${folder}/`);
-			console.log(files);
+
+			for (const file of files) {
+				if (file.includes(".gresource")) {
+					return file;
+				}
+			}
 		} catch (err) {
 			if (process.env.G_MESSAGES_DEBUG === "all") {
 				console.error("Reading file caused this error:", err);

--- a/src/findGResourceAsset.ts
+++ b/src/findGResourceAsset.ts
@@ -1,0 +1,26 @@
+const { readdirSync } = require("fs");
+const { execSync } = require("child_process");
+const { knownGResourceAssets } = require("./knownGResourceAssets");
+
+interface Props {
+	theme: string;
+	folder: string;
+}
+
+export const findGResourceAsset = ({ theme, folder }: Props) => {
+	const asset = knownGResourceAssets[theme.toLocaleLowerCase()];
+
+	if (asset != null) {
+		console.log(asset);
+		return asset;
+	} else {
+		try {
+			const files = readdirSync(`${folder}/`);
+			console.log(files);
+		} catch (err) {
+			if (process.env.G_MESSAGES_DEBUG === "all") {
+				console.error("Reading file caused this error:", err);
+			}
+		}
+	}
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
 } from "./interfaces";
 import { themeFolders } from "./themeFolders";
 import { findGResourceAsset } from "./findGResourceAsset";
+import { convertGResource } from "./convertGResource";
 
 class GtkTheme implements IGtkTheme {
 	private themeName: string;
@@ -99,6 +100,14 @@ class GtkTheme implements IGtkTheme {
 		const themes = themeFolders(name);
 		let theme: string = "";
 		let css: string;
+		const gresourceAsset = findGResourceAsset({
+			theme: name,
+			folder: `${theme}/gtk-3.0/`
+		});
+
+		if (gresourceAsset) {
+			css = convertGResource(gresourceAsset);
+		}
 
 		if ("" !== themes.snap) {
 			theme = themes.snap;
@@ -112,22 +121,16 @@ class GtkTheme implements IGtkTheme {
 			theme = themes.global;
 		}
 
-		try {
-			css = fs.readFileSync(`${theme}/gtk-3.0/gtk.css`, {
-				encoding: "utf8"
-			});
-		} catch (error) {
-			if (process.env.G_MESSAGES_DEBUG === "all") {
-				console.error("Reading file caused this error:", error);
-			}
-			css = "";
-		}
-
-		if (css === "" || css == null) {
+		if (css != null && css !== "" && !gresourceAsset) {
 			try {
-				console.log();
-			} catch (err) {
-				console.error(err);
+				css = fs.readFileSync(`${theme}/gtk-3.0/gtk.css`, {
+					encoding: "utf8"
+				});
+			} catch (error) {
+				if (process.env.G_MESSAGES_DEBUG === "all") {
+					console.error("Reading file caused this error:", error);
+				}
+				css = "";
 			}
 		}
 
@@ -165,15 +168,6 @@ class GtkTheme implements IGtkTheme {
 			decoration.indexOf(":") === decoration.length - 1
 				? "left"
 				: "right";
-
-		const gresourceFound = findGResourceAsset({
-			theme: name,
-			folder: gtk.folder
-		});
-
-		if (gresourceFound) {
-		}
-
 		const theme = {
 			name,
 			gtk,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import { themeName } from './themeName';
-import { decorationLayout } from './decorationLayout';
-import fs from 'fs';
-import path from 'path';
-import { homedir } from 'os';
+import { themeName } from "./themeName";
+import { decorationLayout } from "./decorationLayout";
+import fs from "fs";
+import path from "path";
+import { homedir } from "os";
 import {
 	IGtkTheme,
 	GtkData,
@@ -11,10 +11,10 @@ import {
 	GTKThemeHooks,
 	GTKThemeOptions,
 	NGtkCSSData,
-	NGtkSupportedData,
-} from './interfaces';
-import { themeFolders } from './themeFolders';
-
+	NGtkSupportedData
+} from "./interfaces";
+import { themeFolders } from "./themeFolders";
+import { findGResourceAsset } from "./findGResourceAsset";
 
 class GtkTheme implements IGtkTheme {
 	private themeName: string;
@@ -22,10 +22,10 @@ class GtkTheme implements IGtkTheme {
 
 	on: IGtkThemeEventList = {};
 
-	private hooks: GTKThemeHooks = { prefetch: [] };
+	private hooks: GTKThemeHooks = { prefetch: [], postfetch: [] };
 
 	private themeChanged = (event: string) => {
-		if (event === 'change') {
+		if (event === "change") {
 			const data = this.getTheme();
 
 			if (this.themeName !== data.name) {
@@ -45,7 +45,7 @@ class GtkTheme implements IGtkTheme {
 		}
 	};
 
-	constructor (options: GTKThemeOptions) {
+	constructor(options: GTKThemeOptions) {
 		const { hooks, events } = options;
 
 		if (hooks != null) {
@@ -71,61 +71,78 @@ class GtkTheme implements IGtkTheme {
 			}
 		}
 
-		fs.watch(path.resolve(`${homedir()}/.config/dconf`), { encoding: 'utf8' }, this.themeChanged);
+		fs.watch(
+			path.resolve(`${homedir()}/.config/dconf`),
+			{ encoding: "utf8" },
+			this.themeChanged
+		);
 	}
 
 	/**
 	 * Get the supported buttons & whether CSD is supported.
 	 */
-	private getSupported (decoration: string = ''): NGtkSupportedData {
+	private getSupported(decoration: string = ""): NGtkSupportedData {
 		return {
-			buttons: decoration.split(":").filter((button: string) => button !== 'appmenu')[0].split(','),
+			buttons: decoration
+				.split(":")
+				.filter((button: string) => button !== "appmenu")[0]
+				.split(","),
 			// TODO: Make this check for version of GTK.
-			csd: true,
+			csd: true
 		};
 	}
 
 	/**
 	 * Gets the relevant information for the GTK css.
 	 */
-	private getGtkObj (name: string): NGtkCSSData {
+	private getGtkObj(name: string): NGtkCSSData {
 		const themes = themeFolders(name);
-		let theme: string = '';
+		let theme: string = "";
 		let css: string;
 
-		if ('' !== themes.snap) {
+		if ("" !== themes.snap) {
 			theme = themes.snap;
 		}
 
-		if ('' !== themes.user) {
+		if ("" !== themes.user) {
 			theme = themes.user;
 		}
 
-		if ('' !== themes.global || '' === theme) {
+		if ("" !== themes.global || "" === theme) {
 			theme = themes.global;
 		}
 
 		try {
-			css = fs.readFileSync(`${theme}/gtk-3.0/gtk.css`, { encoding: 'utf8' })
+			css = fs.readFileSync(`${theme}/gtk-3.0/gtk.css`, {
+				encoding: "utf8"
+			});
 		} catch (error) {
-			if (process.env.G_MESSAGES_DEBUG === 'all') {
-				console.error('Reading file caused this error:', error);
+			if (process.env.G_MESSAGES_DEBUG === "all") {
+				console.error("Reading file caused this error:", error);
 			}
-			css = '';
+			css = "";
+		}
+
+		if (css === "" || css == null) {
+			try {
+				console.log();
+			} catch (err) {
+				console.error(err);
+			}
 		}
 
 		return {
 			css,
 			folder: `${theme}/gtk-3.0/`,
-			root: theme || '',
+			root: theme || ""
 		};
 	}
 
-	private clone (obj: any) {
+	private clone(obj: any) {
 		return JSON.parse(JSON.stringify(obj));
 	}
 
-	public getTheme (): GtkData {
+	public getTheme(): GtkData {
 		// Hook into a pre fetch of the theme.
 		// Synchronous
 		if (this.hooks.prefetch.length > 0) {
@@ -134,20 +151,42 @@ class GtkTheme implements IGtkTheme {
 			}
 		}
 
-		const name: string = themeName().split(`'`).join('').replace(/\n$/, '');
-		const decoration: string = decorationLayout().split(`'`).join('').replace(/\n$/, '');
+		const name: string = themeName()
+			.split(`'`)
+			.join("")
+			.replace(/\n$/, "");
+		const decoration: string = decorationLayout()
+			.split(`'`)
+			.join("")
+			.replace(/\n$/, "");
 		const gtk: NGtkCSSData = this.getGtkObj(name);
 		const supported: NGtkSupportedData = this.getSupported(decoration);
-		const buttons: 'left' | 'right' = decoration.indexOf(':') === decoration.length - 1 ? 'left' : 'right';
+		const buttons: "left" | "right" =
+			decoration.indexOf(":") === decoration.length - 1
+				? "left"
+				: "right";
+
+		const gresourceFound = findGResourceAsset({
+			theme: name,
+			folder: gtk.folder
+		});
+
+		if (gresourceFound) {
+		}
+
 		const theme = {
 			name,
 			gtk,
 			supported,
-			layout: { buttons, decoration }
+			layout: {
+				buttons,
+				decoration
+			}
 		};
+
 		let postfetchedTheme = this.clone(theme);
 
-		if (this.hooks.prefetch.length > 0) {
+		if (this.hooks.postfetch.length > 0) {
 			for (const hook of this.hooks.postfetch) {
 				const r = this.clone(hook(theme));
 				if (!!r) {
@@ -167,5 +206,5 @@ export {
 	IGtkThemeEventList,
 	prefetch,
 	GTKThemeHooks,
-	GTKThemeOptions,
+	GTKThemeOptions
 };

--- a/src/knownGResourceAssets.ts
+++ b/src/knownGResourceAssets.ts
@@ -1,0 +1,4 @@
+export const knownGResourceAssets = {
+	yaru: "/usr/share/themes/Yaru/gtk-3.0/gtk.gresource",
+	"yaru-dark": "/usr/share/themes/Yaru-dark/gtk-3.20/gtk.gresource"
+};

--- a/src/knownGResourceAssets.ts
+++ b/src/knownGResourceAssets.ts
@@ -1,4 +1,4 @@
-export const knownGResourceAssets = {
+export const knownGResourceAssets: { [key: string]: string } = {
 	yaru: "/usr/share/themes/Yaru/gtk-3.0/gtk.gresource",
 	"yaru-dark": "/usr/share/themes/Yaru-dark/gtk-3.20/gtk.gresource"
 };

--- a/src/themeName.ts
+++ b/src/themeName.ts
@@ -1,4 +1,7 @@
-const { execSync } = require('child_process');
+import { execSync } from "child_process";
 
 // Return a function to get the current theme.
-export const themeName = () => execSync('gsettings get org.gnome.desktop.interface gtk-theme', { encoding: 'utf8' });
+export const themeName = () =>
+	execSync("gsettings get org.gnome.desktop.interface gtk-theme", {
+		encoding: "utf8"
+	});

--- a/src/tryFolder.ts
+++ b/src/tryFolder.ts
@@ -1,13 +1,13 @@
-import { statSync } from 'fs';
+import { statSync } from "fs";
 
 export const tryFolder = (folder: string) => {
-    try {
-        statSync(folder);
-        return folder;
-    } catch (error) {
-        if (process.env.G_MESSAGES_DEBUG === 'all') {
-            console.error(error);
-        }
-        return '';
+  try {
+    statSync(folder);
+    return folder;
+  } catch (error) {
+    if (process.env.G_MESSAGES_DEBUG === "all") {
+      console.error(error);
     }
-}
+    return "";
+  }
+};


### PR DESCRIPTION
This adds support for any gresource asset located in the same folder as the gtk file.

## Confirmed working
- Yaru (default ubuntu setup)
- Yaru-Dark

## TODO
- Figure out adwaita & gnome's ways of not providing usable assets.
- Possibly pull out gresource library for node w/ proper bindings etc.

## Closes
#1 